### PR TITLE
added tag_string_autocomplete_hidden preset; fixed scheming_multiple_choice_tags_output validation

### DIFF
--- a/ckanext/scheming/presets.json
+++ b/ckanext/scheming/presets.json
@@ -34,6 +34,19 @@
       }
     },
     {
+      "preset_name": "tag_string_autocomplete_hidden",
+      "values": {
+        "validators": "ignore_missing tag_string_convert",
+        "classes": ["control-full", "hidden"],
+        "form_attrs": {
+          "data-module": "autocomplete",
+          "data-module-tags": "",
+          "data-module-source": "/api/2/util/tag/autocomplete?incomplete=?",
+          "class": ""
+        }
+      }
+    },
+    {
       "preset_name": "dataset_organization",
       "values": {
         "validators": "owner_org_validator unicode_safe",

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -387,12 +387,15 @@ def scheming_multiple_choice_output(value):
 @register_validator
 def scheming_multiple_choice_tags_output(value):
     """
-    return stored comma separated list as a proper list
+    return stored comma separated string list as a proper list
     """
     if isinstance(value, list):
-        return value.lower()
+        return value
     try:
-        return value.lower().split( "," )
+        if len(value) == 0:
+            return []
+        else:
+            return value.split( "," )
     except ValueError:
         return [value]
 


### PR DESCRIPTION
need tag_string field to populate with the values from
primary_tags and secondary_tags so that the tags add
and delete properly

fixed scheming_multiple_choice_tags_output so that it correctly
returns an empty list when there are no tags selected