### PR TITLE
Modified scheming_multiple_choice validator

### DIFF
--- a/ckanext/scheming/helpers.py
+++ b/ckanext/scheming/helpers.py
@@ -433,3 +433,15 @@ def scheming_flatten_subfield(subfield, data):
         for k in record:
             flat[prefix + k] = record[k]
     return flat
+
+@helper
+def twdh_scheming_groups_choices(dummy_var='none'):
+    """Return a list of groups for scheming choices helper"""
+    import ckan.plugins.toolkit as toolkit
+    groups = toolkit.get_action('group_list')({}, {'all_fields': True})
+
+    group_choices = [{
+        'value': g['name'],
+        'label': g['display_name']
+    } for g in groups]
+    return group_choices

--- a/ckanext/scheming/validation.py
+++ b/ckanext/scheming/validation.py
@@ -128,7 +128,8 @@ def scheming_multiple_choice(field, schema):
 
         selected = set()
         for element in value:
-            if element in choice_values:
+            # if choice_values is empty, presume element is valid
+            if not choice_values or element in choice_values :
                 selected.add(element)
                 continue
             errors[key].append(_('unexpected choice "%s"') % element)


### PR DESCRIPTION
Previously, if choice_values list was empty and field values existed, validation would fail.

Now, if choice_values is empty and values exist, those values are presumed to be valid.

This fix is being made to address the circular logic case where a choice_list is temporarily unavailable due to resource update order when datapusher-plus is doing a resubmit.